### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/assets/vendor/vendor/php-email-form/validate.js
+++ b/assets/vendor/vendor/php-email-form/validate.js
@@ -72,9 +72,18 @@
     });
   }
 
+  function escapeHtml(unsafe) {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').innerHTML = escapeHtml(error);
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sporadica/Virtual-Portfolio/security/code-scanning/1](https://github.com/sporadica/Virtual-Portfolio/security/code-scanning/1)

To fix the problem, we need to ensure that any error messages written to the innerHTML of an element are properly sanitized to prevent XSS vulnerabilities. The best way to fix this is to escape any HTML special characters in the error message before writing it to the innerHTML.

We can create a utility function to escape HTML special characters and use this function to sanitize the error message before displaying it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
